### PR TITLE
Fix FAQ icon layout + SweetAlert scroll jump; minor responsive polish

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/*    /index.html   200
+/* /index.html 200

--- a/index.css
+++ b/index.css
@@ -4,8 +4,10 @@
 
 @layer base {
   html, body, #root { width: 100%; overflow-x: hidden; }
-  html { overflow-y: scroll; }        
   *, *::before, *::after { box-sizing: border-box; }
   img, video { max-width: 100%; height: auto; display: block; }
 }
 
+html { scrollbar-gutter: stable; }
+
+body { overflow-y: auto; } 

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -10,8 +10,9 @@ const Contact = () => {
       text: "Thank you for contacting us. We will get back to you soon.",
       icon: "success",
       confirmButtonColor: "#f59e0b",
+      scrollbarPadding: false,   
+      heightAuto: false          
     });
-
     e.target.reset();
   };
 
@@ -22,7 +23,6 @@ const Contact = () => {
         className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-amber-200/60 to-transparent"
       />
 
-      {/* Hero */}
       <section className="relative mx-auto max-w-6xl px-4 pt-10">
         <div className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-amber-300 via-yellow-300 to-amber-200 p-8 md:p-10 shadow-lg">
           <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight text-slate-900">
@@ -35,7 +35,6 @@ const Contact = () => {
         </div>
       </section>
 
-      {/* Form */}
       <section className="mx-auto max-w-3xl px-4 mt-10">
         <form
           onSubmit={handleSubmit}
@@ -88,7 +87,6 @@ const Contact = () => {
         </form>
       </section>
 
-      {/* Contact cards */}
       <section className="mx-auto max-w-6xl px-4 mt-6 pb-14">
         <div className="grid md:grid-cols-3 gap-4">
           {[

--- a/src/components/FAQ.js
+++ b/src/components/FAQ.js
@@ -160,9 +160,16 @@ const FAQ = () => {
                       </span>
                       {item.q}
                     </span>
-                    <span className="ml-3 select-none inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-slate-500 transition group-open:rotate-45 group-open:border-amber-500 group-open:text-amber-600">
-                      +
+
+                    <span
+                      className="ml-3 grid place-items-center w-6 h-6 rounded-full border border-slate-300 text-slate-500 transition group-open:rotate-45 group-open:border-amber-500 group-open:text-amber-600 shrink-0"
+                      aria-hidden="true"
+                    >
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                        <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                      </svg>
                     </span>
+
                   </summary>
                   <p className="mt-3 text-sm leading-6 text-slate-600">{item.a}</p>
                 </details>
@@ -189,9 +196,15 @@ const FAQ = () => {
                 >
                   <summary className="cursor-pointer list-none font-semibold flex items-center justify-between text-slate-900 focus-visible:outline-none">
                     {it.q}
-                    <span className="ml-3 select-none inline-flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-slate-500 transition group-open:rotate-45 group-open:border-amber-500 group-open:text-amber-600">
-                      +
+                    <span
+                      className="ml-3 grid place-items-center w-6 h-6 rounded-full border border-slate-300 text-slate-500 transition group-open:rotate-45 group-open:border-amber-500 group-open:text-amber-600 shrink-0"
+                      aria-hidden="true"
+                    >
+                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                        <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                      </svg>
                     </span>
+
                   </summary>
                   <p className="mt-3 text-sm leading-6 text-slate-600">{it.a}</p>
                 </details>


### PR DESCRIPTION
- FAQ: lock the + icon into its own column so it never stretches on 2-line questions (mobile-safe).
- Contact: SweetAlert2 configured with scrollbarPadding: false and heightAuto: false to stop page jump.
- Global: stable scrollbar to prevent layout shift (html { scrollbar-gutter: stable }).
- Minor UI tidy-ups (no change to business logic).
